### PR TITLE
BRA-34: Add page to test which techniques for wrapping text around images work on native mobile browsers

### DIFF
--- a/src/pages/main.css
+++ b/src/pages/main.css
@@ -1,54 +1,16 @@
-html {
-  font-size: 10px;
-}
-
-p {
-  font-size: 2rem;
-  margin-top: 75px;
-}
-
 .container {
-  background: black;
-  display: flex;
+  width: 300px;
 }
 
-.column {
-  flex-direction: column;
+.image {
+  background-color: red;
+  border-radius: 50%;
+  float: left;
+  margin: 0 10px 10px 0;
+  height: 75px;
+  width: 75px;
 }
 
-.box {
-  background: red;
-  height: 50px;
-  margin: 10px;
-  width: 50px;
-}
-
-.stretch > .box {
-  flex: 1;
-}
-
-.align_end {
-  align-items: flex-end;
-  height: 100px;
-  justify-content: flex-end;
-}
-
-.various_sizes {
-  height: 200px;
-}
-
-.various_sizes > .box:nth-of-type(1n) {
-  align-self: flex-start;
-  flex-grow: 3;
-}
-
-.various_sizes > .box:nth-of-type(2n) {
-  background: linear-gradient(to bottom, red 0%, black 100%);
-  align-self: center;
-  flex-grow: 2;
-}
-
-.various_sizes > .box:nth-of-type(3n) {
-  align-self: flex-end;
-  flex-grow: 1;
+.shape {
+  shape-outside: margin-box;
 }

--- a/src/pages/rulebook.html
+++ b/src/pages/rulebook.html
@@ -7,35 +7,25 @@
         <link href="main.css" rel="stylesheet" type="text/css" />
     </head>
     <body>
-        <p>Row</p>
-        <div class="container row">
-            <div class="box">1</div>
-            <div class="box">2</div>
-            <div class="box">3</div>
+        <h1>Wrapping text with a simple float.</h1>
+        <div class="container">
+            <div class="image"></div>
+            <p>
+            Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
+            tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At
+            vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren,
+            no sea takimata sanctus est Lorem ipsum dolor sit amet.
+            </p>
         </div>
-        <p>Column</p>
-        <div class="container column">
-            <div class="box">1</div>
-            <div class="box">2</div>
-            <div class="box">3</div>
-        </div>
-        <p>Grow active</p>
-        <div class="container stretch">
-            <div class="box">1</div>
-            <div class="box">2</div>
-            <div class="box">3</div>
-        </div>
-        <p>Justify content and align items to end</p>
-        <div class="container align_end">
-            <div class="box">1</div>
-            <div class="box">2</div>
-            <div class="box">3</div>
-        </div>
-        <p>Various sizes and self alignments</p>
-        <div class="container various_sizes">
-            <div class="box">1</div>
-            <div class="box">2</div>
-            <div class="box">3</div>
+        <h1>Wrapping text with float and shape-outside.</h1>
+        <div class="container">
+            <div class="image shape"></div>
+            <p>
+            Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
+            tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At
+            vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren,
+            no sea takimata sanctus est Lorem ipsum dolor sit amet.
+            </p>
         </div>
     </body>
 </html>


### PR DESCRIPTION
**What it does**

Tests which techniques for wrapping text around images work on native mobile browsers. We tested two cases: one with a simple float and one with the shape-outside property.